### PR TITLE
Fix build on GCC 13

### DIFF
--- a/src/general/file.h
+++ b/src/general/file.h
@@ -1,6 +1,7 @@
 #ifndef __IO_H__
 #define __IO_H__
 
+#include <cstdint>
 #include <vector>
 #include <string>
 #include <cstddef>

--- a/src/general/filelist.h
+++ b/src/general/filelist.h
@@ -1,6 +1,7 @@
 #ifndef __FILES_H__
 #define __FILES_H__
 
+#include <cstdint>
 #include <vector>
 #include <string>
 


### PR DESCRIPTION
GCC 13 stopped transitively including `cstdint` in a couple of scenarios [^1], which leads to build failures akin to:

```
[ 25%] Building CXX object src/general/CMakeFiles/General.dir/file.cpp.o
In file included from /build/source/src/general/file.cpp:1:
/build/source/src/general/file.h:10:27: error: 'uint8_t' was not declared in this scope
   10 | void readFile(std::vector<uint8_t> &res, const char *fname,
      |                           ^~~~~~~
/build/source/src/general/file.h:8:1: note: 'uint8_t' is defined in header '<cstdint>'; did you forget to '#include <cstdint>'?
    7 | #include "error.h"
  +++ |+#include <cstdint>
    8 |
```

As an example of this issue in the wild, see this Nixpkgs CI failure:
Build: https://hydra.nixos.org/build/246246828
Build log: https://hydra.nixos.org/build/246246828/nixlog/1

This change includes `cstdint` in `general/file.h` and `general/filelist.h`, fixing the build on current GCC versions.

[^1]: https://www.gnu.org/software/gcc/gcc-13/porting_to.html#header-dep-changes